### PR TITLE
Refactors ingest task

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If there were errors, or if you can't see the running website, then please [file
 You can also ingest into a server which is already up and running.
 
 ```
-OV_HOST=1.2.3.4 OV_SSH_KEY=~/.ssh/xyz.wgbh-mla-test.org.pem OV_PBCORE=fm-export.zip bundle exec cap demo ingest:run
+bundle exec cap demo ingest:run OV_HOST=1.2.3.4 OV_SSH_KEY=~/.ssh/xyz.wgbh-mla-test.org.pem OV_PBCORE=fm-export.zip
 ```
 
 

--- a/lib/capistrano/tasks/ingest.rake
+++ b/lib/capistrano/tasks/ingest.rake
@@ -1,35 +1,37 @@
-# Relative path to remote PBCore file
-# NOTE: WE pass a lambda here to lazy eval, so we only check for env var when
-#   trying to access :ov_pbcore_file. The `set' method does not take a block
-#   hence the stabby lambda.
-set :ov_pbcore_file, -> do
-  raise ArgumentError, 'Missing required environment variable OV_PBCORE' unless ENV['OV_PBCORE']
-  "ingest_data/#{File.basename(ENV['OV_PBCORE'])}"
-end
+task :ingest do
+  on roles(:web) do
+    local_path = ENV['OV_PBCORE'].to_s.strip
+    raise ArgumentError, 'Missing required environment variable OV_PBCORE' if local_path == ''
 
-namespace :ingest do
-  task :upload do
-    on roles(:web) do
-      with rails_env: :production do
-        execute :mkdir, '-p', "#{release_path}/#{File.dirname(fetch(:ov_pbcore_file))}"
-        upload! ENV['OV_PBCORE'], "#{release_path}/#{fetch(:ov_pbcore_file)}"
-      end
+    # Create the dir that stores the ingest source files or directories, if it doesn't already exist.
+    remote_ingest_data_dir = "#{shared_path}/tmp/ingest_data"
+    execute :mkdir, '-p', remote_ingest_data_dir
+
+    if File.directory? local_path
+      ingest_source_type = '--dirs'
+    elsif File.file? local_path
+      ingest_source_type = '--files'
+    else
+      raise ArgumentError, "OV_PBCORE must be a file or directory path, but '#{ENV['OV_PBCORE']}' was given"
     end
-  end
 
-  task :run do
-    on roles(:web) do
+    # TODO: clear out remote_ingest_data_dir directory before uploading?
+    upload! local_path, remote_ingest_data_dir, recursive: true
+
+    within release_path do
       with rails_env: :production do
-        within release_path do
-          unless test("[ -f #{release_path}/#{fetch(:ov_pbcore_file)} ]")
-            raise "PBCore file not found. Upload pbcore with:\n\n\tOV_PBCORE=path/to/pbcore_file cap #{fetch(:stage)} ingest:upload\n\n"
-          end
-          execute :bundle, 'exec', 'ruby', "#{release_path}/scripts/ingest.rb", "--same-mount", '--files', "#{release_path}/#{fetch(:ov_pbcore_file)}"
-          invoke 'deploy:restart'
+        # Start jetty if it isn't already running.
+        jetty_status = capture :bundle, 'exec', 'rake', 'jetty:status'
+        if jetty_status == 'Not running'
+          invoke 'jetty:start'
         end
+
+        remote_ingest_data_path = "#{remote_ingest_data_dir}/#{File.basename(local_path)}"
+        execute :bundle, 'exec', 'ruby', "#{release_path}/scripts/ingest.rb", '--same-mount', ingest_source_type, remote_ingest_data_path
+
+        # Restart the rails app
+        invoke 'deploy:restart'
       end
     end
   end
-
-  task :upload_and_run => [:upload, :run]
 end


### PR DESCRIPTION
No longer 2 separate tasks for ingest:upload and ingest:run. Instead, just use:
    
      bundle exec cap [stage] ingest OV_HOST=[host ip] OV_SSH_KEY=[path to ssh key] OV_PBCORE=[path to files or directory]