### PR TITLE
Refactors jetty tasks

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,9 @@ ask :branch, 'master'
 # set :keep_releases, 5
 
 namespace :deploy do
+  after :updated, :ensure_jetty_is_installed do
+    invoke 'jetty:install'
+  end
 
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do

--- a/lib/capistrano/tasks/jetty.rake
+++ b/lib/capistrano/tasks/jetty.rake
@@ -1,37 +1,68 @@
 namespace :jetty do
-
-  task :config do
+  # Open Vault has a `jetty:restart` task, but it doesn't work in the context
+  # of capistrano. Here we have to explicitly stop, then start. Also, we add a
+  # friendlier error message if jetty is not currently present.
+  desc 'Restarts jetty'
+  task :restart do
     on roles(:web) do
       within release_path do
         with rails_env: :production do
-          execute :rake, 'jetty:config'
-        end
-      end
-    end
-  end
+          if test "[ ! -L #{release_path}/jetty ]"
+            raise 'No jetty detected. Install jetty with: bundle exec cap [stage] jetty:install'
+          end
 
-  task :start do
-    on roles(:web) do
-      within release_path do
-        with rails_env: :production do
+          # This is a little hairy, but it gets the PIDs of all running jetty
+          # processes. There shouldn't be more than 1, but we want to kill
+          # them all.
+          jetty_pids = capture("ps ax | grep 'jetty/solr -jar start.jar' | grep -v 'grep' | awk '{print $1}'").split(/\s/)
+          jetty_pids.each do |jetty_pid|
+            execute :kill, jetty_pid
+          end
           execute :rake, 'jetty:start'
         end
       end
     end
   end
 
-  task :clean do
+  desc 'Installs a new jetty instance if one does not exist'
+  task :install do
     on roles(:web) do
       within release_path do
         with rails_env: :production do
-          execute :rm, '-rf', "#{shared_path}/jetty"
-          execute :rake, 'jetty:clean'
-          execute :mv, 'jetty', shared_path
-          execute :ln, '-s', "#{shared_path}/jetty"
+          # Download a clean copy of jetty if one doesn't already exist
+          if test "[ ! -d #{shared_path}/jetty ]"
+            execute :rake, 'jetty:clean'
+            execute :mv, 'jetty', shared_path
+          end
+
+          # Create link to shared jetty if it doesn't already exists
+          execute :ln, '-s', "#{shared_path}/jetty"  if test("[ ! -L #{release_path}/jetty ]")
+
+          # Configure and restart jetty instance
+          execute :rake, 'jetty:config'
+
+          # Use our own jetty:restart instead of `rake jetty:restart`, which
+          # does not work when invoked from Capistrano.
+          invoke 'jetty:restart'
         end
       end
     end
   end
 
-  task :prepare => [:clean, :config, :start]
+  desc 'WARNING!!! Uninstalls jetty and all the data with it!'
+  task :uninstall do
+    on roles(:web) do
+      within release_path do
+        with rails_env: :production do
+          # Remove the shared jetty instance
+          execute :rm, '-rf', "#{shared_path}/jetty"
+
+          # Remove symlink to shared jetty instance if it exists
+          if test("[ -L #{release_path}/jetty ]")
+            execute :rm, "#{release_path}/jetty"  
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Limits tasks to those that need to be exposed.
* Combines tasks that need to be paired together to ensure a good state.
* Removes the following tasks:
  * `jetty:config` - does not need to be a separate task
  * `jetty:start` - replaced by :restart
  * `jetty:clean` - refactored
  * `jetty:prepare` - refactored
* Adds the following tasks:
  * `jetty:restart` - replaces :start
  * `jetty:install` - does a fresh install if needed, sets up symlink and
     config, and then restarts. This task is invoked by :deploy.
  * `jetty:uninstall` - Removes shared jetty and any symlinks

Closes #38, closes #40