### PR TITLE
Adds verification of git status

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,3 +1,6 @@
+# Add ./lib dir to load path
+$:.unshift(File.expand_path('lib'))
+
 # Load DSL and set up stages
 require 'capistrano/setup'
 
@@ -22,6 +25,8 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/passenger'
+
+require 'git_helper'
 
 # Load custom tasks from `lib/capistrano/tasks' if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,11 +5,9 @@ set :application, 'openvault'
 set :repo_url, 'https://github.com/WGBH/openvault3.git'
 set :rails_env, 'production'
 
-if ENV['OV_BRANCH']
-  set :branch, ENV['OV_BRANCH']
-else
-  ask :branch, 'master'
-end
+# Require confirmation by user if the repo is in a dirty state.
+include GitHelper
+verify_git_status!
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log')
 namespace :deploy do

--- a/lib/git_helper.rb
+++ b/lib/git_helper.rb
@@ -1,0 +1,52 @@
+module GitHelper
+  def git_status
+    `git status`.chomp
+  end
+
+  def git_dirty?
+    git_status !~ /Your branch is up-to-date with 'origin\/master.*nothing to commit, working directory clean'/
+  end
+
+  def git_out_of_sync?
+    git_current_rev != git_origin_master_rev
+  end
+
+  def git_is_up_to_date_and_clean?
+    git_origin_master_rev == git_current_rev && !git_dirty?
+  end
+
+  def git_current_branch
+    `git rev-parse --abbrev-ref HEAD`.chomp
+  end
+
+  def git_current_rev
+    `git rev-parse HEAD`.chomp
+  end
+
+  def git_origin_master_rev
+    `git rev-parse origin/master`.chomp
+  end
+
+
+  def verify_git_status!
+    if git_dirty? || git_out_of_sync
+      puts <<-EOS
+
+WARNING! The current status of your repository is not in sync with the master branch in Github.
+
+=========== CURRENT GIT STATUS ===========
+#{git_status}
+============= END GIT STATUS =============
+
+Your current branch: #{git_current_branch}
+Your current revision: #{git_current_rev}
+
+Github's current revision: #{git_origin_master_rev}
+
+EOS
+      
+      ask(:response, 'You must type "yes" to proceed using your git repository in its current state')
+      abort("Operation canceled by user\n\n") unless fetch(:response).downcase == 'yes'
+    end
+  end
+end


### PR DESCRIPTION
* If the git repository is either dirty, or not up-to-date, it will require the
  user to enter 'yes' before proceeding.
* Removes ability to set branch using env var. Instead, require the user have
  intended branch checked out locally.

Closes #46.