### PR TITLE
Only show git status warning when needed.

### DIFF
--- a/lib/git_helper.rb
+++ b/lib/git_helper.rb
@@ -4,7 +4,7 @@ module GitHelper
   end
 
   def git_dirty?
-    git_status !~ /Your branch is up-to-date with 'origin\/master.*nothing to commit, working directory clean'/
+    git_status !~ /Your branch is up-to-date with 'origin\/master.*nothing to commit, working directory clean/
   end
 
   def git_out_of_sync?
@@ -29,22 +29,25 @@ module GitHelper
 
 
   def verify_git_status!
-    if git_dirty? || git_out_of_sync
-      puts <<-EOS
+    if git_dirty? || git_out_of_sync?
+      puts "\nWARNING! The current status of your repository is not in sync with the master branch in Github.\n\n"
 
-WARNING! The current status of your repository is not in sync with the master branch in Github.
+      # Display git status if working tree is dirty
+      if git_dirty?
+        puts  "=========== CURRENT GIT STATUS ===========",
+              git_status,
+              "============= END GIT STATUS =============\n\n"
+      end
 
-=========== CURRENT GIT STATUS ===========
-#{git_status}
-============= END GIT STATUS =============
-
-Your current branch: #{git_current_branch}
-Your current revision: #{git_current_rev}
-
-Github's current revision: #{git_origin_master_rev}
-
-EOS
+      # Display branch/revision info if different from remote
+      if git_out_of_sync?
+        puts "Your branch and revision: #{git_current_branch}"
+        puts "Your current revision: #{git_current_rev}"
+        puts "\nGithub's branch: master"
+        puts "Github's revision: #{git_origin_master_rev}\n"
+      end
       
+      # Abort the task unless the user explicitly types 'yes'
       ask(:response, 'You must type "yes" to proceed using your git repository in its current state')
       abort("Operation canceled by user\n\n") unless fetch(:response).downcase == 'yes'
     end


### PR DESCRIPTION
* Does not show the git status warning if the working tree is clean, and up to
  date with origin/master (the assumed remote).
* Only shows git status if working tree is dirty, and only shows branch/revision
  if it differs from origin/master. This is to avoid a point of confusion that
  @Muraszko pointed out.

Fixes #60.