### PR TITLE
Adds cap task to check current git revision

### DIFF
--- a/lib/capistrano/tasks/revision.rake
+++ b/lib/capistrano/tasks/revision.rake
@@ -1,0 +1,8 @@
+desc 'Print the current Git revision'
+task :revision do
+  on roles(:web) do
+    within current_path do
+      puts "\nCurrent Git revision: #{capture(:cat, "REVISION")}\n\n"
+    end
+  end
+end


### PR DESCRIPTION
Usage:

    # Print the current Git revision for the 'aws' stage on host 1.2.3.4
    bundle exec cap aws revision OV_HOST=1.2.3.4 OV_SSH_KEY=path/to/ssh_key.pem